### PR TITLE
fix shop crash, add logging, sort weapons

### DIFF
--- a/BetterSorting.cs
+++ b/BetterSorting.cs
@@ -124,6 +124,7 @@ namespace BetterSorting
                     if ((instruction.operand as MethodInfo)?.Name == "set_value")
                     {
                         instList[idx - 1].opcode = OpCodes.Ldc_I4_1;
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
- fixes a crash when toggling filters in the shop screen
- refactored the shop sorting so it can be called from the comparison
function that the shop uses
- added logging
- added fallback to sort by name on exception
- updated shop sorting to count +'s instead of bonuses for weapons
TODO: refactor the code base to generate a single 'sort val' that can be
used everywhere?